### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         config: [debug, release]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       
     - uses: benjlevesque/short-sha@v1.2
       id: short-sha
@@ -86,9 +86,9 @@ jobs:
         if exist support cp -r support %PACKAGE_NAME%
         if exist tests cp -r tests %PACKAGE_NAME%
         
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.event.repository.name }}-${{ steps.short-sha.outputs.sha }}-${{ matrix.config }}
+        name: ${{ github.event.repository.name }}-${{ steps.short-sha.outputs.sha }}-${{ matrix.config }}-${{ matrix.os }}
         path: ${{ github.event.repository.name }}
 
   release:
@@ -102,7 +102,7 @@ jobs:
       with:
         length: 7
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ github.event.repository.name }}-${{ steps.short-sha.outputs.sha }}-release
         path: ${{ github.event.repository.name }}
@@ -114,7 +114,7 @@ jobs:
     - name: zip
       run: zip -r ${{ github.event.repository.name }}-package-for-max-${{ steps.short-sha.outputs.sha }}.zip ${{ github.event.repository.name }}
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ github.event.repository.name }}-${{ steps.short-sha.outputs.sha }}-zipped-release
         path: ${{ github.event.repository.name }}-package-for-max-${{ steps.short-sha.outputs.sha }}.zip


### PR DESCRIPTION
- update `actions/download-artifact` to non deprecated v4
- update `actions/upload-artifact` to non deprecated v4
- update `actions/checkout` to faster v4
- add `-${{ matrix.os }}` at end of artifact to differentiate the mac and windows version and not abort part of the workflow with an error